### PR TITLE
Added with_stream() to tls_socket.rs, to create a new channel from an existing stream

### DIFF
--- a/rust-thrift-tls/src/tls_socket.rs
+++ b/rust-thrift-tls/src/tls_socket.rs
@@ -55,6 +55,17 @@ where
         }
     }
 
+    /// Create a `TLSTTcpChannel` from an existing TLSStream<S>.
+    ///
+    /// The returned instance must be opened using `TLSTTcpChannel::open(...)`
+    /// before it can be used.
+    pub fn with_stream(stream: TLSStream<S>) -> TLSTTcpChannel<S> {
+        TLSTTcpChannel {
+            stream: Option::from(stream),
+            shutdown: Shutdown::Both,
+        }
+    }
+
     /// Shut down this channel.
     ///
     /// Both send and receive halves are closed, and this instance can no


### PR DESCRIPTION
I needed to be able to pass in an existing TLSStream when creating a TLSTTcpChannel because I am managing the TLS ClientSession and underlying TcpStream myself. This is very similar to the with_stream() functionality built into the Apache Thrift library at https://github.com/apache/thrift/blob/master/lib/rs/src/transport/socket.rs starting on line 78.